### PR TITLE
fix event bubbling in view event handler

### DIFF
--- a/packages/ember-views/lib/views/states/has_element.js
+++ b/packages/ember-views/lib/views/states/has_element.js
@@ -19,9 +19,11 @@ assign(hasElement, {
     if (view.has(eventName)) {
       // Handler should be able to re-dispatch events, so we don't
       // preventDefault or stopPropagation.
-      return flaggedInstrument(`interaction.${eventName}`, { event, view }, () => {
+      flaggedInstrument(`interaction.${eventName}`, { event, view }, () => {
         return run.join(view, view.trigger, eventName, event);
       });
+
+      return view.bubbles;
     } else {
       return true; // continue event propagation
     }


### PR DESCRIPTION
Fixes 
- nested routes and link-to arguments: The {{link-to}} helper supports bubbles=false
- nested routes and link-to arguments: The {{link-to}} helper supports bubbles=boundFalseyThing